### PR TITLE
Removed custom string class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ Thumbs.db
 /Default.xml
 /documentation/
 /build/
+/.vs/
+/out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.1...3.18)
 include(cmake/csys_utils.cmake)
 
 # Configure library version
-set(CSYS_MAJOR_VERSION 1)
+set(CSYS_MAJOR_VERSION 2)
 set(CSYS_MINOR_VERSION 0)
 set(CSYS_PATCH_VERSION 0)
 set(CSYS_VERSION

--- a/include/csys/arguments.h
+++ b/include/csys/arguments.h
@@ -22,9 +22,9 @@ namespace csys
     template<> \
     struct CSYS_API ArgData<TYPE> \
     { \
-      explicit ArgData(String name) : m_Name(std::move(name)), m_Value() {} \
-      const String m_Name; \
-      String m_TypeName = TYPE_NAME; \
+      explicit ArgData(std::string name) : m_Name(std::move(name)), m_Value() {} \
+      const std::string m_Name; \
+      std::string m_TypeName = TYPE_NAME; \
       TYPE m_Value; \
     };
 
@@ -51,16 +51,16 @@ namespace csys
          * \param name
          *      Name of the argument
          */
-        explicit ArgData(String name) : m_Name(std::move(name)), m_Value()
+        explicit ArgData(std::string name) : m_Name(std::move(name)), m_Value()
         { }
 
-        const String m_Name = "";                  //!< Name of argument
-        String m_TypeName = "Unsupported Type";    //!< Name of type
+        const std::string m_Name = "";                  //!< Name of argument
+        std::string m_TypeName = "Unsupported Type";    //!< Name of type
         T m_Value;                                 //!< Actual value
     };
 
     //! Supported types
-    SUPPORT_TYPE(String, "String")
+    SUPPORT_TYPE(std::string, "String")
 
     SUPPORT_TYPE(bool, "Boolean")
 
@@ -101,12 +101,12 @@ namespace csys
          * \param name
          *      Name for argument
          */
-        explicit ArgData(String name) : m_Name(std::move(name))
+        explicit ArgData(std::string name) : m_Name(std::move(name))
         {}
 
-        const String m_Name;                                                                   //!< Name of argument
-        String m_TypeName = std::string("Vector_Of_") + ArgData<T>("").m_TypeName.m_String;    //!< Type name
-        std::vector<T> m_Value;                                                                //!< Vector of data
+        const std::string m_Name;                                                                   //!< Name of argument
+        std::string m_TypeName = std::string("Vector_Of_") + ArgData<T>("").m_TypeName;             //!< Type name
+        std::vector<T> m_Value;                                                                     //!< Vector of data
     };
 
     /*!
@@ -136,7 +136,7 @@ namespace csys
          * \param name
          *      Name of the argument
          */
-        explicit Arg(const String &name) : m_Arg(name)
+        explicit Arg(const std::string &name) : m_Arg(name)
         {
             static_assert(is_supported_type_v<ValueType>,
                     "ValueType 'T' is not supported, see 'Supported types' for more help");
@@ -152,13 +152,13 @@ namespace csys
          * \return
          *      Returns this
          */
-        Arg<T> &Parse(String &input, size_t &start)
+        Arg<T> &Parse(std::string &input, size_t &start)
         {
             size_t index = start;
 
             // Check if there are more arguments to be read in
-            if (input.NextPoi(index).first == input.End())
-                throw Exception("Not enough arguments were given", input.m_String);
+            if (NextPoi(input, index).first == EndPoi(input))
+                throw Exception("Not enough arguments were given", input);
             // Set value grabbed from input aka command line argument
             m_Arg.m_Value = ArgumentParser<ValueType>(input, start).m_Value;
             return *this;
@@ -172,7 +172,7 @@ namespace csys
          */
         std::string Info()
         {
-            return std::string(" [") + m_Arg.m_Name.m_String + ":" + m_Arg.m_TypeName.m_String + "]";
+            return std::string(" [") + m_Arg.m_Name + ":" + m_Arg.m_TypeName + "]";
         }
 
         ArgData<ValueType> m_Arg;    //!< Data relating to this argument
@@ -196,10 +196,10 @@ namespace csys
          * \return
          *      Returns this
          */
-        Arg<NULL_ARGUMENT> &Parse(String &input, size_t &start)
+        Arg<NULL_ARGUMENT> &Parse(std::string &input, size_t &start)
         {
-            if (input.NextPoi(start).first != input.End())
-                throw Exception("Too many arguments were given", input.m_String);
+            if (NextPoi(input, start).first != EndPoi(input))
+                throw Exception("Too many arguments were given", input);
             return *this;
         }
     };

--- a/include/csys/command.h
+++ b/include/csys/command.h
@@ -35,7 +35,7 @@ namespace csys
          * \return
          *      Returns item error if the parsing in someway was messed up, and none if there was no issue
          */
-        virtual Item operator()(String &input) = 0;
+        virtual Item operator()(std::string &input) = 0;
 
         /*!
          * \brief
@@ -87,10 +87,10 @@ namespace csys
          * \param args
          *      Arguments to be used for parsing and passing into the function. Must be of type "Arg<T>"
          */
-        Command(String name, String description, Fn function, Args... args) : m_Name(std::move(name)),
-                                                                              m_Description(std::move(description)),
-                                                                              m_Function(function),
-                                                                              m_Arguments(args..., Arg<NULL_ARGUMENT>())
+        Command(std::string name, std::string description, Fn function, Args... args) : m_Name(std::move(name)),
+                                                                                        m_Description(std::move(description)),
+                                                                                        m_Function(function),
+                                                                                        m_Arguments(args..., Arg<NULL_ARGUMENT>())
         {}
 
         /*!
@@ -101,7 +101,7 @@ namespace csys
          * \return
          *      Returns item error if the parsing in someway was messed up, and none if there was no issue
          */
-        Item operator()(String &input) final
+        Item operator()(std::string &input) final
         {
             try
             {
@@ -112,7 +112,7 @@ namespace csys
             catch (Exception &ae)
             {
                 // Error happened with parsing
-                return Item(ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(ERROR) << (m_Name + ": " + ae.what());
             }
             return Item(NONE);
         }
@@ -125,8 +125,8 @@ namespace csys
          */
         [[nodiscard]] std::string Help() final
         {
-            return m_Name.m_String + DisplayArguments(std::make_index_sequence<sizeof ...(Args)>{}) + "\n\t\t- " +
-                   m_Description.m_String + "\n\n";
+            return m_Name + DisplayArguments(std::make_index_sequence<sizeof ...(Args)>{}) + "\n\t\t- " +
+                   m_Description + "\n\n";
         }
 
         /*!
@@ -162,7 +162,7 @@ namespace csys
          *      String of arguments to be parsed
          */
         template<size_t... Is_p, size_t... Is_c>
-        void Call(String &input, const std::index_sequence<Is_p...> &, const std::index_sequence<Is_c...> &)
+        void Call(std::string &input, const std::index_sequence<Is_p...> &, const std::index_sequence<Is_c...> &)
         {
             size_t start = 0;
 
@@ -188,8 +188,8 @@ namespace csys
             return (std::get<Is>(m_Arguments).Info() + ...);
         }
 
-        const String m_Name;                                            //!< Name of command
-        const String m_Description;                                     //!< Description of the command
+        const std::string m_Name;                                       //!< Name of command
+        const std::string m_Description;                                //!< Description of the command
         std::function<void(typename Args::ValueType...)> m_Function;    //!< Function to be invoked as command
         std::tuple<Args..., Arg<NULL_ARGUMENT>> m_Arguments;            //!< Arguments to be passed into m_Function
     };
@@ -215,9 +215,9 @@ namespace csys
          * \param function
          *      Function to run when command is called
          */
-        Command(String name, String description, Fn function) : m_Name(std::move(name)),
-                                                                m_Description(std::move(description)),
-                                                                m_Function(function), m_Arguments(Arg<NULL_ARGUMENT>())
+        Command(std::string name, std::string description, Fn function) : m_Name(std::move(name)),
+                                                                          m_Description(std::move(description)),
+                                                                          m_Function(function), m_Arguments(Arg<NULL_ARGUMENT>())
         {}
 
         /*!
@@ -228,7 +228,7 @@ namespace csys
          * \return
          *      Returns item error if the parsing in someway was messed up, and none if there was no issue
          */
-        Item operator()(String &input) final
+        Item operator()(std::string &input) final
         {
             // call the function
             size_t start = 0;
@@ -240,7 +240,7 @@ namespace csys
             catch (Exception &ae)
             {
                 // Command had something passed into it
-                return Item(ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(ERROR) << (m_Name + ": " + ae.what());
             }
 
             // Call function
@@ -256,7 +256,7 @@ namespace csys
          */
         [[nodiscard]] std::string Help() final
         {
-            return m_Name.m_String + "\n\t\t- " + m_Description.m_String + "\n\n";
+            return m_Name + "\n\t\t- " + m_Description + "\n\n";
         }
 
         /*!
@@ -282,8 +282,8 @@ namespace csys
         }
     private:
 
-        const String m_Name;                           //!< Name of command
-        const String m_Description;                    //!< Description of the command
+        const std::string m_Name;                      //!< Name of command
+        const std::string m_Description;               //!< Description of the command
         std::function<void(void)> m_Function;          //!< Function to be invoked as command
         std::tuple<Arg<NULL_ARGUMENT>> m_Arguments;    //!< Arguments to be passed into m_Function
     };

--- a/include/csys/string.h
+++ b/include/csys/string.h
@@ -12,99 +12,48 @@
 namespace csys
 {
     /*!
-     * \brief
-     *      Wrapper around std::string to be used with parsing a string argument
-     */
-    struct CSYS_API String
+        * \brief
+        *      Moves until first non-whitespace char, and continues until the end of the string or a whitespace has is
+        *      found
+        * \param start
+        *      Where to start scanning from. Will be set to pair.second
+        * \return
+        *      Returns the first element and one passed the end of non-whitespace. In other words [first, second)
+        */
+    inline std::pair<size_t, size_t> NextPoi(const std::string& str, size_t &start)
     {
-        /*!
-         * \brief
-         *      Default constructor
-         */
-        String() = default;
+        size_t end = str.size();
+        std::pair<size_t, size_t> range(end + 1, end);
+        size_t pos = start;
 
-        /*!
-         * \brief
-         *      Conversion constructor from c-style string. A deep copy is made
-         * \param str
-         *      String to be converted
-         */
-        String(const char *str [[maybe_unused]]) : m_String(str ? str : "")
-        {}
+        // Go to the first non-whitespace char
+        for (; pos < end; ++pos)
+            if (!std::isspace(str[pos]))
+            {
+                range.first = pos;
+                break;
+            }
 
-        /*!
-         * \brief
-         *      Conversion constructor from an std::string to csys::String. A deep copy is made
-         * \param str
-         *      String to be converted
-         */
-        String(std::string str) : m_String(std::move(str))
-        {}
+        // Go to the first whitespace char
+        for (; pos < end; ++pos)
+            if (std::isspace(str[pos]))
+            {
+                range.second = pos;
+                break;
+            }
 
-        /*!
-         * \brief
-         *      Conversion constructor from csys::String to a c-style string
-         * \return
-         *      Returns a pointer to the string contained within this string
-         */
-        operator const char *()
-        { return m_String.c_str(); }
+        start = range.second;
+        return range;
+    }
 
-        /*!
-         * \brief
-         *      Conversion constructor from csys::String to an std::string
-         * \return
-         *      Returns a copy of this string
-         */
-        operator std::string()
-        { return m_String; }
-
-        /*!
-         * \brief
-         *      Moves until first non-whitespace char, and continues until the end of the string or a whitespace has is
-         *      found
-         * \param start
-         *      Where to start scanning from. Will be set to pair.second
-         * \return
-         *      Returns the first element and one passed the end of non-whitespace. In other words [first, second)
-         */
-        std::pair<size_t, size_t> NextPoi(size_t &start) const
-        {
-            size_t end = m_String.size();
-            std::pair<size_t, size_t> range(end + 1, end);
-            size_t pos = start;
-
-            // Go to the first non-whitespace char
-            for (; pos < end; ++pos)
-                if (!std::isspace(m_String[pos]) && m_String[pos] != '\0')
-                {
-                    range.first = pos;
-                    break;
-                }
-
-            // Go to the first whitespace char
-            for (; pos < end; ++pos)
-                if (std::isspace(m_String[pos]) || m_String[pos] == '\0')
-                {
-                    range.second = pos;
-                    break;
-                }
-
-            start = range.second;
-            return range;
-        }
-
-        /*!
-         * \brief
-         *      Returns a value to be compared with the .first of the pair returned from NextPoi
-         * \return
-         *      Returns size of string + 1
-         */
-        [[nodiscard]] size_t End() const
-        { return m_String.size() + 1; }
-
-        std::string m_String;    //!< String data member
-    };
+    /*!
+        * \brief
+        *      Returns a value to be compared with the .first of the pair returned from NextPoi
+        * \return
+        *      Returns size of string + 1
+        */
+    [[nodiscard]] inline size_t EndPoi(const std::string& str)
+    { return str.size() + 1; }
 }
 
 #endif //CSYS_CSYS_STRING_H

--- a/include/csys/system.inl
+++ b/include/csys/system.inl
@@ -237,21 +237,21 @@ namespace csys
     // Private methods ////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////
 
-    CSYS_INLINE void System::ParseCommandLine(const String &line)
+    CSYS_INLINE void System::ParseCommandLine(const std::string &line)
     {
         // Get first non-whitespace char.
         size_t line_index = 0;
-        std::pair<size_t, size_t> range = line.NextPoi(line_index);
+        std::pair<size_t, size_t> range = NextPoi(line, line_index);
 
         // Just whitespace was passed in. Don't log as command.
-        if (range.first == line.End())
+        if (range.first == EndPoi(line))
             return;
 
         // Push to history.
-        m_CommandHistory.PushBack(line.m_String);
+        m_CommandHistory.PushBack(line);
 
         // Get name of command.
-        std::string command_name = line.m_String.substr(range.first, range.second - range.first);
+        std::string command_name = line.substr(range.first, range.second - range.first);
 
         // Set or get
         bool is_cmd_set = command_name == s_Set;
@@ -261,22 +261,22 @@ namespace csys
         // Edge case for if user is just runs "help" command
         if (is_cmd_help)
         {
-            range = line.NextPoi(line_index);
-            if (range.first != line.End())
-                command_name += " " + line.m_String.substr(range.first, range.second - range.first);
+            range = NextPoi(line, line_index);
+            if (range.first != EndPoi(line))
+                command_name += " " + line.substr(range.first, range.second - range.first);
         }
 
             // Its a set or get command
         else if (is_cmd_set || is_cmd_get)
         {
             // Try to get variable name
-            if ((range = line.NextPoi(line_index)).first == line.End())
+            if ((range = NextPoi(line, line_index)).first == EndPoi(line))
             {
                 Log(ERROR) << s_ErrorNoVar << endl;
                 return;
             } else
                 // Append variable name.
-                command_name += " " + line.m_String.substr(range.first, range.second - range.first);
+                command_name += " " + line.substr(range.first, range.second - range.first);
         }
 
         // Get runnable command
@@ -287,7 +287,7 @@ namespace csys
         else
         {
             // Get the arguments.
-            String arguments = line.m_String.substr(range.second, line.m_String.size() - range.first);
+            std::string arguments = line.substr(range.second, line.size() - range.first);
 
             // Execute command.
             auto cmd_out = (*command->second)(arguments);

--- a/tests/test_string_argument.cpp
+++ b/tests/test_string_argument.cpp
@@ -12,81 +12,76 @@ TEST_CASE("String Argument")
 	System s;
 
 // CORRECT USAGE SINGLE WORD
-	String strt;
-    s.RegisterCommand("0", "", [&strt](String str)
+	std::string strt;
+    s.RegisterCommand("0", "", [&strt](std::string str)
     {
         strt = str;
 //			std::cout << "String -> " << str.m_String << std::endl;
-    }, Arg<String>(""));
-
-    s.RegisterCommand("1", "", [](const char *str)
-    {
-                CHECK(!strcmp(str, "One"));
-    }, Arg<String>(""));
+    }, Arg<std::string>(""));
 
     s.RegisterCommand("2", "", [](std::string str)
     {
                 CHECK(str == "Two");
-    }, Arg<String>(""));
+    }, Arg<std::string>(""));
 
     s.RegisterCommand("3", "", [](std::string str)
     {
                 CHECK(str == "");
-    }, Arg<String>(""));
+    }, Arg<std::string>(""));
 
     s.RunCommand("0 \" \""); // Zero\] -> Zero\]
-	CHECK((strt.m_String == " "));
+	CHECK((strt == " "));
 
 	// single word strings
     s.RunCommand("0 Zero\\]"); // Zero\] -> Zero\]
-	CHECK((strt.m_String == "Zero]"));
-	strt.m_String.clear();
+	CHECK((strt == "Zero]"));
+	strt.clear();
 
     s.RunCommand("0 \"Zero\\\"\""); // Zero\] -> Zero\]
-  CHECK((strt.m_String == "Zero\""));
-	strt.m_String.clear();
+  CHECK((strt == "Zero\""));
+	strt.clear();
 
     s.RunCommand("0 \"Zero \\\" \\\\\""); // Zero\] -> Zero\]
-					CHECK((strt.m_String == "Zero \" \\"));
-	strt.m_String.clear();
+					CHECK((strt == "Zero \" \\"));
+	strt.clear();
 
     s.RunCommand("0 \"Zero\"\"One\"\"    #    \""); // Zero\] -> Zero\]
-					CHECK((strt.m_String == "ZeroOne    #    "));
-	strt.m_String.clear();
+					CHECK((strt == "ZeroOne    #    "));
+	strt.clear();
 
 // CORRECT USAGE MANY WORDS
-    s.RegisterCommand("0,1", "", [](String str, String str1)
+    s.RegisterCommand("0,1", "", [](std::string str, std::string str1)
     {
-        bool zero = str.m_String == "Zero";
-        bool one = str1.m_String == "One";
+        bool zero = str == "Zero";
+        bool one = str1 == "One";
                 CHECK(zero);
                 CHECK(one);
-    }, Arg<String>(""), Arg<String>(""));
+    }, Arg<std::string>(""), Arg<std::string>(""));
 
 	// multi word strings
     s.RunCommand("0,1 \"Zero\" \"One\"");
     s.RunCommand("0,1     Zero    One    ");
 
 // CORRECT USAGE VECTOR OF MULTI WORD(S)
-    s.RegisterCommand("0,1,2", "", [](std::vector<String> strs)
+    s.RegisterCommand("0,1,2", "", [](std::vector<std::string> strs)
     {
         std::string ar[] = {"Zero", "One", "Two"};
 //		for(auto &str: strs) std::cout << str << std::endl;
         for (unsigned i = 0; i < 3; ++i)
-            if (strs[i].m_String != ar[i])
+            if (strs[i] != ar[i])
             {
 //				std::cout << "CHECK: " << strs[i].m_String << " != " << ar[i] << std::endl;
                         CHECK(false);
                 return;
             }
                 CHECK(true);
-    }, Arg<std::vector<String>>(""));
+    }, Arg<std::vector<std::string>>(""));
 
 	// multi word strings
     s.RunCommand("0,1,2 [  \"Zero\" \"One\" \"Two\"   ]");
 
 // CORRECT USAGE VECTOR OF VECTOR OF MULTI WORD(S)
-    s.RegisterCommand("0,1,2,3", "", [](std::vector<std::vector<String>>)
+    s.RegisterCommand("0,1,2,3", "", [](std::vector<std::vector<std::string>>)
     {
         std::vector<std::vector<std::string>> arr = {{"One",    "Two"},
                                                      {" |Three| |Yeet|"},
@@ -96,16 +91,16 @@ TEST_CASE("String Argument")
 //		CHECK((strs[1][0].m_String == arr[1][0]));
 //		CHECK((strs[2][0].m_String == arr[2][0]));
 //		CHECK((strs[2][1].m_String == arr[2][1]));
-    }, Arg<std::vector<std::vector<String>>>(""));
+    }, Arg<std::vector<std::vector<std::string>>>(""));
 
 	// multi word strings
     s.RunCommand("0,1,2,3 [ [\"Arg\"] ]");
 
-    s.RegisterCommand("vecvecvec", "", [](std::vector<std::vector<std::vector<String>>> strs)
+    s.RegisterCommand("vecvecvec", "", [](std::vector<std::vector<std::vector<std::string>>> strs)
     {
-        bool c = strs[0][0][0].m_String == " " && strs[1][0][0].m_String == "Arg";
+        bool c = strs[0][0][0] == " " && strs[1][0][0] == "Arg";
                 CHECK(c);
-    }, Arg<std::vector<std::vector<std::vector<String>>>>(""));
+    }, Arg<std::vector<std::vector<std::vector<std::string>>>>(""));
 
     s.RunCommand("vecvecvec  [ \
 														[ \

--- a/tests/test_system.cpp
+++ b/tests/test_system.cpp
@@ -12,6 +12,7 @@ TEST_CASE ("Test CSYS System Class")
     { test_flag = flag; };
     float time_variable = 0;
     int temp_var = 0;
+    std::string temp_str = "hello";
 
     // Test Command registration.
     temp.RegisterCommand("test", "Simple description", fn, csys::Arg<bool>("Test_Argument"));
@@ -26,7 +27,7 @@ TEST_CASE ("Test CSYS System Class")
     // Registration.
     temp.RegisterVariable("time", time_variable, csys::Arg<float>(""));
     temp.RegisterVariable("temp_var", temp_var, csys::Arg<int>(""));
-
+    temp.RegisterVariable("temp_str", temp_str, csys::Arg<std::string>(""));
     temp.RegisterVariable("time_set", time_variable, setter);
 
     temp.RunCommand("set time_set 30");
@@ -39,6 +40,8 @@ TEST_CASE ("Test CSYS System Class")
     CHECK(time_variable == 15);
     temp.RunCommand("set temp_var 30");
     CHECK(temp_var == 30);
+    temp.RunCommand("set temp_str buffalo");
+    CHECK(temp_str == "buffalo");
 
     // Test system variables.
     temp.UnregisterVariable("time");


### PR DESCRIPTION
With the custom string class, there is no way to use `RegisterVariable` with a `std::string` variable.
This does break using `RegisterCommand` with a string `csys::Arg` and having the callable accept a `const char*` parameter.