### PR TITLE
Update CSYS ItemType enum

### DIFF
--- a/include/csys/command.h
+++ b/include/csys/command.h
@@ -112,7 +112,7 @@ namespace csys
             catch (Exception &ae)
             {
                 // Error happened with parsing
-                return Item(ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(CSYS_ERROR) << (m_Name.m_String + ": " + ae.what());
             }
             return Item(NONE);
         }
@@ -240,7 +240,7 @@ namespace csys
             catch (Exception &ae)
             {
                 // Command had something passed into it
-                return Item(ERROR) << (m_Name.m_String + ": " + ae.what());
+                return Item(CSYS_ERROR) << (m_Name.m_String + ": " + ae.what());
             }
 
             // Call function

--- a/include/csys/item.h
+++ b/include/csys/item.h
@@ -28,7 +28,7 @@ namespace csys
         COMMAND = 0,
         LOG,
         WARNING,
-        ERROR,
+        CSYS_ERROR,
         INFO,
         NONE
     };

--- a/include/csys/item.inl
+++ b/include/csys/item.inl
@@ -45,7 +45,7 @@ namespace csys
                 return '\t' + m_Data;
             case WARNING:
                 return s_Warning.data() + m_Data;
-            case ERROR:
+            case CSYS_ERROR:
                 return s_Error.data() + m_Data;
             case INFO:
                 return m_Data;

--- a/include/csys/system.h
+++ b/include/csys/system.h
@@ -102,7 +102,7 @@ namespace csys
          * \brief
          *      Creates a new item entry to log information
          * \param type
-         *      Log type (COMMAND, LOG, WARNING, ERROR)
+         *      Log type (COMMAND, LOG, WARNING, CSYS_ERROR)
          * \return
          *      Reference to console items obj
          */
@@ -169,7 +169,7 @@ namespace csys
             // Check if command has a name
             else if (range.first == name.End())
             {
-                Log(ERROR) << "Empty command name given" << csys::endl;
+                Log(CSYS_ERROR) << "Empty command name given" << csys::endl;
                 return;
             }
 

--- a/include/csys/system.inl
+++ b/include/csys/system.inl
@@ -121,7 +121,7 @@ namespace csys
         // Exit if not found.
         if (script_pair == m_Scripts.end())
         {
-            m_ItemLog.log(ERROR) << "Script \"" << script_name << "\" not found" << csys::endl;
+            m_ItemLog.log(CSYS_ERROR) << "Script \"" << script_name << "\" not found" << csys::endl;
             return;
         }
 
@@ -137,7 +137,7 @@ namespace csys
             }
             catch (csys::Exception &e)
             {
-                Log(ERROR) << e.what() << csys::endl;
+                Log(CSYS_ERROR) << e.what() << csys::endl;
             }
         }
 
@@ -272,7 +272,7 @@ namespace csys
             // Try to get variable name
             if ((range = line.NextPoi(line_index)).first == line.End())
             {
-                Log(ERROR) << s_ErrorNoVar << endl;
+                Log(CSYS_ERROR) << s_ErrorNoVar << endl;
                 return;
             } else
                 // Append variable name.
@@ -282,7 +282,7 @@ namespace csys
         // Get runnable command
         auto command = m_Commands.find(command_name);
         if (command == m_Commands.end())
-            Log(ERROR) << s_ErrorSetGetNotFound << endl;
+            Log(CSYS_ERROR) << s_ErrorSetGetNotFound << endl;
             // Run the command
         else
         {


### PR DESCRIPTION
Changed the ERROR to CSYS_ERROR to avoid conflict with Windows wingdi.h macro.

With the old enum name, naming conflicts will occur when built with `windows.h` included. This is because `wingdi.h` is included by `windows.h`, and ERROR is defined as a macro keyword.

This can in return lead to `expected identifier before numeric constant` error because ERROR is resolved as value 0.

To avoid this conflict, I refactored the code and changed the enum keyword to CSYS_ERROR.